### PR TITLE
Move moof and mdat generation to fragment level

### DIFF
--- a/packager/media/formats/mp4/fragmenter.h
+++ b/packager/media/formats/mp4/fragmenter.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "packager/base/logging.h"
+#include "packager/media/formats/mp4/box_definitions.h"
 #include "packager/status.h"
 
 namespace shaka {
@@ -32,10 +33,12 @@ class Fragmenter {
  public:
   /// @param info contains stream information.
   /// @param traf points to a TrackFragment box.
+  /// @param moof points to the moof MetaData
   /// @param edit_list_offset is the edit list offset that is encoded in Edit
   ///        List. It should be 0 if there is no EditList.
   Fragmenter(std::shared_ptr<const StreamInfo> info,
              TrackFragment* traf,
+             MovieFragment* moof,
              int64_t edit_list_offset);
 
   ~Fragmenter();
@@ -67,6 +70,7 @@ class Fragmenter {
   bool fragment_initialized() const { return fragment_initialized_; }
   bool fragment_finalized() const { return fragment_finalized_; }
   BufferWriter* data() { return data_.get(); }
+  BufferWriter* fragment() { return fragment_.get(); }
   const std::vector<KeyFrameInfo>& key_frame_infos() const {
     return key_frame_infos_;
   }
@@ -87,6 +91,7 @@ class Fragmenter {
 
   std::shared_ptr<const StreamInfo> stream_info_;
   TrackFragment* traf_ = nullptr;
+  MovieFragment* moof_ = nullptr;
   int64_t edit_list_offset_ = 0;
   int64_t seek_preroll_ = 0;
   bool fragment_initialized_ = false;
@@ -95,6 +100,7 @@ class Fragmenter {
   int64_t earliest_presentation_time_ = 0;
   int64_t first_sap_time_ = 0;
   std::unique_ptr<BufferWriter> data_;
+  std::unique_ptr<BufferWriter> fragment_;
   // Saves key frames information, for Video.
   std::vector<KeyFrameInfo> key_frame_infos_;
 

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -165,6 +165,10 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
       return Status::OK;
   }
 
+  // Set the moof offset. Note this value will always equal '0' with the
+  // current implementation because of the assumption that each segment only 
+  // contains one fragment. Therefore, the moof will always be at the start 
+  // of the segment. 
   const uint64_t moof_start_offset = fragment_buffer_->Size();
   bool first_key_frame = true;
   for (const std::unique_ptr<Fragmenter>& fragmenter : fragmenters_) {
@@ -187,7 +191,7 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
     sidx_->references.resize(sidx_->references.size() + 1);
     fragmenters_[GetReferenceStreamId()]->GenerateSegmentReference(
         &sidx_->references[sidx_->references.size() - 1]);
-    sidx_->references[sidx_->references.size() - 1].referenced_size +=
+    sidx_->references[sidx_->references.size() - 1].referenced_size =
         fragmenter->fragment()->Size();
   }
 

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -178,7 +178,8 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
       first_key_frame = false;
       key_frame_infos_.push_back(
           {key_frame_info.timestamp, moof_start_offset,
-           fragment_buffer_->Size() - moof_start_offset + key_frame_info.size});
+           (fragmenter->fragment()->Size() - fragmenter->data()->Size() 
+            - moof_start_offset + key_frame_info.size)});
     }
     fragment_buffer_->AppendBuffer(*fragmenter->fragment());
 


### PR DESCRIPTION
- Refactor moof and mdat generation to occur at the fragment level rather than the segment level
- Ensure that the sidx calculation, which remains at the segment level, is preserved

NOTE:
- This feature is necessary for enabling multiple fragments per mp4 segment, since each fragment requires it's own metadata. The previous structure assumes that each segment will only have one fragment. 