### PR TITLE
LL-DASH mode flag name change

### DIFF
--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -76,7 +76,7 @@ DEFINE_bool(dash_force_segment_list,
             "is greater than what the sidx atom allows (65535). Currently "
             "this flag is only supported in DASH ondemand profile.");
 DEFINE_bool(
-    is_low_latency_dash,
+    low_latency_dash_mode,
     false,
     "If enabled, LL-DASH streaming will be used, "
     "reducing overall latency by decoupling latency from segment duration. "

--- a/packager/app/mpd_flags.h
+++ b/packager/app/mpd_flags.h
@@ -24,6 +24,6 @@ DECLARE_bool(allow_approximate_segment_timeline);
 DECLARE_bool(allow_codec_switching);
 DECLARE_bool(include_mspr_pro_for_playready);
 DECLARE_bool(dash_force_segment_list);
-DECLARE_bool(is_low_latency_dash);
+DECLARE_bool(low_latency_dash_mode);
 
 #endif  // APP_MPD_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -325,7 +325,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   ChunkingParams& chunking_params = packaging_params.chunking_params;
   chunking_params.segment_duration_in_seconds = FLAGS_segment_duration;
   chunking_params.subsegment_duration_in_seconds = FLAGS_fragment_duration;
-  chunking_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
+  chunking_params.low_latency_dash_mode = FLAGS_low_latency_dash_mode;
   chunking_params.segment_sap_aligned = FLAGS_segment_sap_aligned;
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
@@ -436,7 +436,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   mp4_params.generate_sidx_in_media_segments =
       FLAGS_generate_sidx_in_media_segments;
   mp4_params.include_pssh_in_stream = FLAGS_mp4_include_pssh_in_stream;
-  mp4_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
+  mp4_params.low_latency_dash_mode = FLAGS_low_latency_dash_mode;
 
   packaging_params.transport_stream_timestamp_offset_ms =
       FLAGS_transport_stream_timestamp_offset_ms;
@@ -476,7 +476,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
       FLAGS_allow_approximate_segment_timeline;
   mpd_params.allow_codec_switching = FLAGS_allow_codec_switching;
   mpd_params.include_mspr_pro = FLAGS_include_mspr_pro_for_playready;
-  mpd_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
+  mpd_params.low_latency_dash_mode = FLAGS_low_latency_dash_mode;
 
   HlsParams& hls_params = packaging_params.hls_params;
   if (!GetHlsPlaylistType(FLAGS_hls_playlist_type, &hls_params.playlist_type)) {

--- a/packager/media/chunking/chunking_handler.cc
+++ b/packager/media/chunking/chunking_handler.cc
@@ -117,7 +117,7 @@ Status ChunkingHandler::OnMediaSample(
   // On each media sample, which is the basis for a chunk,
   // we must increment the current_subsegment_index_
   // in order to hit FinalizeSegment() within Segmenter.
-  if (!started_new_segment && chunking_params_.is_low_latency_dash) {
+  if (!started_new_segment && chunking_params_.low_latency_dash_mode) {
     current_subsegment_index_++;
 
     RETURN_IF_ERROR(EndSubsegmentIfStarted());
@@ -128,7 +128,7 @@ Status ChunkingHandler::OnMediaSample(
   // This fragment size can be set with the 'fragment_duration' cmd arg.
   // This is NOT for the LL-DASH case.
   if (!started_new_segment && IsSubsegmentEnabled() &&
-      !chunking_params_.is_low_latency_dash) {
+      !chunking_params_.low_latency_dash_mode) {
     const bool can_start_new_subsegment =
         sample->is_key_frame() || !chunking_params_.subsegment_sap_aligned;
     if (can_start_new_subsegment) {
@@ -167,7 +167,7 @@ Status ChunkingHandler::EndSegmentIfStarted() const {
   auto segment_info = std::make_shared<SegmentInfo>();
   segment_info->start_timestamp = segment_start_time_.value();
   segment_info->duration = max_segment_time_ - segment_start_time_.value();
-  if (chunking_params_.is_low_latency_dash) {
+  if (chunking_params_.low_latency_dash_mode) {
     segment_info->is_chunk = true;
     segment_info->is_final_chunk_in_seg = true;
   }
@@ -183,7 +183,7 @@ Status ChunkingHandler::EndSubsegmentIfStarted() const {
   subsegment_info->duration =
       max_segment_time_ - subsegment_start_time_.value();
   subsegment_info->is_subsegment = true;
-  if (chunking_params_.is_low_latency_dash)
+  if (chunking_params_.low_latency_dash_mode)
     subsegment_info->is_chunk = true;
   return DispatchSegmentInfo(kStreamIndex, std::move(subsegment_info));
 }

--- a/packager/media/chunking/chunking_handler_unittest.cc
+++ b/packager/media/chunking/chunking_handler_unittest.cc
@@ -209,7 +209,7 @@ TEST_F(ChunkingHandlerTest, CueEvent) {
 
 TEST_F(ChunkingHandlerTest, LowLatencyDash) {
   ChunkingParams chunking_params;
-  chunking_params.is_low_latency_dash = true;
+  chunking_params.low_latency_dash_mode = true;
   chunking_params.segment_duration_in_seconds = 1;
   SetUpChunkingHandler(1, chunking_params);
 

--- a/packager/media/event/mpd_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/mpd_notify_muxer_listener_unittest.cc
@@ -102,7 +102,7 @@ class MpdNotifyMuxerListenerTest : public ::testing::TestWithParam<MpdType> {
     mpd_options.dash_profile = DashProfile::kLive;
     // Low Latency DASH live profile should be dynamic.
     mpd_options.mpd_type = MpdType::kDynamic;
-    mpd_options.mpd_params.is_low_latency_dash = true;
+    mpd_options.mpd_params.low_latency_dash_mode = true;
     notifier_.reset(new MockMpdNotifier(mpd_options));
     listener_.reset(new MpdNotifyMuxerListener(notifier_.get()));
   }

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -299,7 +299,7 @@ Status MP4Muxer::DelayInitializeMuxer() {
   if (options().segment_template.empty()) {
     segmenter_.reset(new SingleSegmentSegmenter(options(), std::move(ftyp),
                                                 std::move(moov)));
-  } else if (options().mp4_params.is_low_latency_dash) {
+  } else if (options().mp4_params.low_latency_dash_mode) {
     segmenter_.reset(new LowLatencySegmentSegmenter(options(), std::move(ftyp),
                                                     std::move(moov)));
   } else {

--- a/packager/media/public/chunking_params.h
+++ b/packager/media/public/chunking_params.h
@@ -30,7 +30,7 @@ struct ChunkingParams {
   /// chunk. A chunk is the smallest unit and is constructed of a single moof
   /// and mdat atom. Each chunk is uploaded immediately upon creation,
   /// decoupling latency from segment duration.
-  bool is_low_latency_dash = false;
+  bool low_latency_dash_mode = false;
 };
 
 }  // namespace shaka

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -25,7 +25,7 @@ struct Mp4OutputParams {
   /// chunk. A chunk is the smallest unit and is constructed of a single moof
   /// and mdat atom. Each chunk is uploaded immediately upon creation,
   /// decoupling latency from segment duration.
-  bool is_low_latency_dash = false;
+  bool low_latency_dash_mode = false;
 };
 
 }  // namespace shaka

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -138,7 +138,7 @@ base::Optional<xml::XmlNode> Period::GetXml(bool output_period_duration) {
     return base::nullopt;
 
   // Required for LL-DASH MPDs.
-  if (mpd_options_.mpd_params.is_low_latency_dash) {
+  if (mpd_options_.mpd_params.low_latency_dash_mode) {
     // Create ServiceDescription element.
     xml::XmlNode service_description_node("ServiceDescription");
     if (!service_description_node.SetIntegerAttribute("id", id_))

--- a/packager/mpd/base/period_unittest.cc
+++ b/packager/mpd/base/period_unittest.cc
@@ -186,7 +186,7 @@ TEST_F(PeriodTest, LowLatencyDashMpdGetXml) {
       "}\n"
       "container_type: 1\n";
   mpd_options_.mpd_type = MpdType::kDynamic;
-  mpd_options_.mpd_params.is_low_latency_dash = true;
+  mpd_options_.mpd_params.low_latency_dash_mode = true;
   mpd_options_.mpd_params.target_latency_seconds = 1;
 
   EXPECT_CALL(testable_period_, NewAdaptationSet(_, _, _))

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -283,7 +283,7 @@ base::Optional<xml::XmlNode> Representation::GetXml() {
   if (HasLiveOnlyFields(media_info_) &&
       !representation.AddLiveOnlyInfo(
           media_info_, segment_infos_, start_number_,
-          mpd_options_.mpd_params.is_low_latency_dash)) {
+          mpd_options_.mpd_params.low_latency_dash_mode)) {
     LOG(ERROR) << "Failed to add Live info.";
     return base::nullopt;
   }

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -461,7 +461,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
     const MediaInfo& media_info,
     const std::list<SegmentInfo>& segment_infos,
     uint32_t start_number,
-    bool is_low_latency_dash) {
+    bool low_latency_dash_mode) {
   XmlNode segment_template("SegmentTemplate");
   if (media_info.has_reference_time_scale()) {
     RCHECK(segment_template.SetIntegerAttribute(
@@ -510,7 +510,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
             std::to_string(last_segment_number)));
       }
     } else {
-      if (!is_low_latency_dash) {
+      if (!low_latency_dash_mode) {
         XmlNode segment_timeline("SegmentTimeline");
         RCHECK(PopulateSegmentTimeline(segment_infos, &segment_timeline));
         RCHECK(segment_template.AddChild(std::move(segment_timeline)));

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -220,7 +220,7 @@ class RepresentationXmlNode : public RepresentationBaseXmlNode {
   bool AddLiveOnlyInfo(const MediaInfo& media_info,
                        const std::list<SegmentInfo>& segment_infos,
                        uint32_t start_number,
-                       bool is_low_latency_dash) WARN_UNUSED_RESULT;
+                       bool low_latency_dash_mode) WARN_UNUSED_RESULT;
 
  private:
   // Add AudioChannelConfiguration element. Note that it is a required element

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -96,7 +96,7 @@ struct MpdParams {
   /// chunk. A chunk is the smallest unit and is constructed of a single moof
   /// and mdat atom. Each chunk is uploaded immediately upon creation,
   /// decoupling latency from segment duration.
-  bool is_low_latency_dash = false;
+  bool low_latency_dash_mode = false;
   /// This is the target latency in seconds requested by the user. The actual
   /// latency may be different to the target latency
   /// and is greatly influnced by the player.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -374,7 +374,7 @@ Status ValidateParams(const PackagingParams& packaging_params,
                   "on-demand profile (not using segment_template or segment list).");
   }
 
-  if (packaging_params.chunking_params.is_low_latency_dash &&
+  if (packaging_params.chunking_params.low_latency_dash_mode &&
       packaging_params.chunking_params.subsegment_duration_in_seconds) {
     // Low latency streaming requires data to be shipped as chunks,
     // the smallest unit of video. Right now, each chunk contains
@@ -384,15 +384,15 @@ Status ValidateParams(const PackagingParams& packaging_params,
     // of desired frames per chunk.
     return Status(error::INVALID_ARGUMENT,
                   "--fragment_duration cannot be set "
-                  "if --is_low_latency_dash is enabled.");
+                  "if --low_latency_dash_mode is enabled.");
   }
 
-  if (packaging_params.mpd_params.is_low_latency_dash &&
+  if (packaging_params.mpd_params.low_latency_dash_mode &&
       packaging_params.mpd_params.utc_timings.empty()) {
     // Low latency DASH MPD requires a UTC Timing value
     return Status(error::INVALID_ARGUMENT,
                   "--utc_timings must be be set "
-                  "if --is_low_latency_dash is enabled.");
+                  "if --low_latency_dash_mode is enabled.");
   }
 
   return Status::OK;

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -269,7 +269,7 @@ TEST_F(PackagerTest, ReadFromBufferFailed) {
 
 TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
   auto packaging_params = SetupPackagingParams();
-  packaging_params.chunking_params.is_low_latency_dash = true;
+  packaging_params.chunking_params.low_latency_dash_mode = true;
   packaging_params.chunking_params.subsegment_duration_in_seconds =
       kFragmentDurationInSeconds;
   Packager packager;
@@ -281,7 +281,7 @@ TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
 
 TEST_F(PackagerTest, LowLatencyDashEnabledAndUtcTimingNotSet) {
   auto packaging_params = SetupPackagingParams();
-  packaging_params.mpd_params.is_low_latency_dash = true;
+  packaging_params.mpd_params.low_latency_dash_mode = true;
   Packager packager;
   auto status = packager.Initialize(packaging_params, SetupStreamDescriptors());
   ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());


### PR DESCRIPTION
- Change the flag and variable name from `is_low_latency_dash` to `low_latency_dash_mode`
- This was done because of the association with the verb "is" and method/function naming schemes. The discussion regarding this change can be found [here](https://github.com/CaitlinOCallaghan/shaka-streamer/pull/3#discussion_r689707425) and [here](https://github.com/CaitlinOCallaghan/shaka-packager/pull/6#discussion_r689939304). 